### PR TITLE
#64 shuffle tools and add ToolManager.js

### DIFF
--- a/src/core/GameManager.js
+++ b/src/core/GameManager.js
@@ -1,14 +1,7 @@
 import { Fruit } from '../models/Fruit.js';
 import { Wall } from '../models/Wall.js';
 import { checkCollision } from '../utils/CheckCollision.js';
-import {
-	RainbowFruit,
-	BombFruit,
-	shuffle,
-	doubleScore,
-	mysteryTool,
-	divineShield,
-} from '../shop/index.js';
+import { ToolManager } from './ToolManager.js';
 
 export class Game {
 	constructor() {
@@ -17,6 +10,8 @@ export class Game {
 		this.currentFruit = null;
 		this.gravity = 15;
 		this.walls = [];
+
+		this.toolManager = new ToolManager(this);
 	}
 
 	setup() {
@@ -27,20 +22,21 @@ export class Game {
 		this.walls = Wall.createDefaultWalls();
 
 		this.currentFruit = new Fruit(0, 300, 25, 30);
-		this.init();
-	}
+		let shuffleButton = createButton('Shake Tool');
+		shuffleButton.mousePressed(() => this.toolManager.activateTool('shuffle'));
 
-	/**
-	 * The init function is used to test if these modules are imported correctly.
-	 * You can check by clicking F12 and checking the console
-	 * When you want to test your own code, remove it from init()
-	 * and move them to the proper place.
-	 */
-	init() {
-		shuffle(this);
-		doubleScore(this);
-		mysteryTool(this);
-		divineShield(this);
+		let defineButton = createButton('defind shield');
+		defineButton.mousePressed(() =>
+			this.toolManager.activateTool('devineShield')
+		);
+
+		let randomToolButton = createButton('Random Tool');
+		randomToolButton.mousePressed(() => this.toolManager.randomTool());
+
+		let doubleScoreToolButton = createButton('double Score');
+		doubleScoreToolButton.mousePressed(() =>
+			this.toolManager.activateTool('doubleScore')
+		);
 	}
 
 	update() {
@@ -48,6 +44,8 @@ export class Game {
 		this.handleCurrentFruit();
 		this.handleMerging();
 		this.fruits = this.fruits.filter((fruit) => !fruit.removed);
+
+		this.toolManager.update();
 	}
 
 	handleCurrentFruit() {

--- a/src/core/GameManager.js
+++ b/src/core/GameManager.js
@@ -62,7 +62,11 @@ export class Game {
 			}
 		}
 
-		if (mouseIsPressed && this.currentFruit) {
+		if (
+			mouseIsPressed &&
+			this.currentFruit &&
+			!this.isClickingUI(mouseX, mouseY)
+		) {
 			this.fruits.push(this.currentFruit);
 			this.currentFruit = null;
 		}
@@ -87,5 +91,20 @@ export class Game {
 				}
 			}
 		}
+	}
+
+	isClickingUI(mx, my) {
+		let uiButtons = selectAll('button');
+		for (let btn of uiButtons) {
+			let bx = btn.position().x;
+			let by = btn.position().y;
+			let bw = btn.width;
+			let bh = btn.height;
+
+			if (mx > bx && mx < bx + bw && my > by && my < by + bh) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/core/ToolManager.js
+++ b/src/core/ToolManager.js
@@ -1,0 +1,43 @@
+import {
+	ShuffleTool,
+	DivineShieldTool,
+	DoubleScoreTool,
+} from '../shop/index.js';
+
+export class ToolManager {
+	constructor(game) {
+		this.game = game;
+		this.tools = {
+			shuffle: new ShuffleTool(game),
+			devineShield: new DivineShieldTool(game),
+			doubleScore: new DoubleScoreTool(game),
+		};
+	}
+
+	update() {
+		for (let key in this.tools) {
+			if (this.tools[key].update) {
+				this.tools[key].update();
+			}
+		}
+	}
+
+	activateTool(toolName) {
+		if (this.tools[toolName]) {
+			this.tools[toolName].activate();
+			console.log(`${toolName} active`);
+		} else {
+			console.error(`Tool "${toolName}" not found!`);
+		}
+	}
+
+	randomTool() {
+		const toolKeys = Object.keys(this.tools);
+		if (toolKeys.length === 0) {
+			return;
+		}
+
+		const randomKey = random(toolKeys);
+		this.activateTool(randomKey);
+	}
+}

--- a/src/shop/DivineShieldTool.js
+++ b/src/shop/DivineShieldTool.js
@@ -1,4 +1,13 @@
-export function divineShield(game) {
-	game.isIncidentMode = true;
-	console.log('🛡️ Divine Shield activated!');
+export class DivineShieldTool {
+	constructor(game) {
+		this.game = game;
+	}
+
+	activate() {
+		console.log('DivineShieldTool active');
+	}
+
+	update() {
+		// console.log('DivineShieldTool close');
+	}
 }

--- a/src/shop/DoubleScoreTool.js
+++ b/src/shop/DoubleScoreTool.js
@@ -1,3 +1,13 @@
-export function doubleScore(game) {
-	console.log('Double Score activated!');
+export class DoubleScoreTool {
+	constructor(game) {
+		this.game = game;
+	}
+
+	activate() {
+		console.log('DoubleScoreTool active');
+	}
+
+	update() {
+		// console.log('DoubleScoreTool close');
+	}
 }

--- a/src/shop/MysteryTool.js
+++ b/src/shop/MysteryTool.js
@@ -1,4 +1,0 @@
-export function mysteryTool(game) {
-	const randomEffect = Math.random() > 0.5 ? 'bonus' : 'penalty';
-	console.log(`Mystery Tool triggered: ${randomEffect}`);
-}

--- a/src/shop/ShuffleTool.js
+++ b/src/shop/ShuffleTool.js
@@ -1,17 +1,37 @@
-export function shuffle(game) {
-	console.log('Fruits shuffled!');
-}
-
 export class ShuffleTool {
 	constructor(game) {
 		this.game = game;
+		this.isShaking = false;
+		this.shakeDuration = 60;
+		this.shakeTimer = 0;
+		this.shakeIntensity = 10;
 	}
 
 	activate() {
-		console.log('ShuffleTool active');
+		if (this.isShaking) return;
+
+		this.isShaking = true;
+		this.shakeTimer = this.shakeDuration;
+
+		for (let fruit of this.game.fruits) {
+			let forceX = random(-this.shakeIntensity * 3, this.shakeIntensity * 3);
+			let forceY = random(-this.shakeIntensity, this.shakeIntensity);
+			fruit.sprite.vel.x += forceX;
+			fruit.sprite.vel.y += forceY;
+		}
 	}
 
 	update() {
-		// console.log('ShuffleTool close');
+		if (this.isShaking) {
+			this.shakeTimer--;
+			if (this.shakeTimer <= 0) {
+				this.isShaking = false;
+
+				for (let fruit of this.game.fruits) {
+					fruit.sprite.vel.x *= 0.9;
+					fruit.sprite.vel.y *= 0.9;
+				}
+			}
+		}
 	}
 }

--- a/src/shop/ShuffleTool.js
+++ b/src/shop/ShuffleTool.js
@@ -1,3 +1,17 @@
 export function shuffle(game) {
 	console.log('Fruits shuffled!');
 }
+
+export class ShuffleTool {
+	constructor(game) {
+		this.game = game;
+	}
+
+	activate() {
+		console.log('ShuffleTool active');
+	}
+
+	update() {
+		// console.log('ShuffleTool close');
+	}
+}

--- a/src/shop/index.js
+++ b/src/shop/index.js
@@ -1,6 +1,5 @@
-export { shuffle } from './ShuffleTool.js';
-export { doubleScore } from './DoubleScoreTool.js';
-export { divineShield } from './DivineShieldTool.js';
-export { mysteryTool } from './MysteryTool.js';
 export { BombFruit } from './BombFruit.js';
+export { DoubleScoreTool } from './DoubleScoreTool.js';
+export { DivineShieldTool } from './DivineShieldTool.js';
 export { RainbowFruit } from './RainbowFruit.js';
+export { ShuffleTool } from './ShuffleTool.js';


### PR DESCRIPTION
I’ve added ToolManager.js to unify the management of tools, including shuffle, double score, divine shield, and mystery tool.
This change mainly affects Gr, Jimmy, me, and Fan.

During implementation, I realized that the previous approach made GameManager.js too complex. With this new structure, it will be easier to expand and manage future tools. Additionally, mystery tool can now call a random tool more efficiently.