### PR TITLE
#124 add keyboard control

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -4,6 +4,16 @@ let game,
 	canvas,
 	scaleVal = 1;
 
+// Track pressed keys for continuous movement
+const keysPressed = {
+	a: false,
+	A: false,
+	d: false,
+	D: false,
+	ArrowLeft: false,
+	ArrowRight: false,
+};
+
 // Use window.setup because in index.html file use type module to allow import and export file.
 window.setup = function () {
 	canvas = createCanvas(1500, 1000);
@@ -16,6 +26,25 @@ window.setup = function () {
 window.draw = function () {
 	background('#f5ebe0');
 	game.draw();
+
+	// Handle continuous key movement in draw loop
+	if (game && game.gameManager && game.gameManager.mode === 'double') {
+		// Player 1 continuous movement
+		if (keysPressed['a'] || keysPressed['A']) {
+			game.gameManager.handleKeyPress('player1-left');
+		}
+		if (keysPressed['d'] || keysPressed['D']) {
+			game.gameManager.handleKeyPress('player1-right');
+		}
+
+		// Player 2 continuous movement
+		if (keysPressed['ArrowLeft']) {
+			game.gameManager.handleKeyPress('player2-left');
+		}
+		if (keysPressed['ArrowRight']) {
+			game.gameManager.handleKeyPress('player2-right');
+		}
+	}
 };
 
 window.windowResized = function () {
@@ -32,4 +61,50 @@ window.windowResized = function () {
 	if (game) {
 		game.updateScale(scaleVal);
 	}
+};
+
+// Track when keys are pressed down
+window.keyPressed = function () {
+	// Start tracking this key as pressed
+	keysPressed[key] = true;
+
+	if (keyCode === LEFT_ARROW) keysPressed['ArrowLeft'] = true;
+	if (keyCode === RIGHT_ARROW) keysPressed['ArrowRight'] = true;
+
+	if (game && game.gameManager) {
+		// Handle drop keys only on initial press
+		if (game.gameManager.mode === 'double') {
+			// Player 1 drop
+			if (key === 's' || key === 'S') {
+				game.gameManager.handleKeyPress('player1-drop');
+			}
+
+			// Player 2 drop
+			if (keyCode === DOWN_ARROW) {
+				game.gameManager.handleKeyPress('player2-drop');
+			}
+		}
+	}
+
+	return false; // Prevent default browser behavior
+};
+
+// Track when keys are released
+window.keyReleased = function () {
+	// Stop tracking this key as pressed
+	keysPressed[key] = false;
+
+	if (keyCode === LEFT_ARROW) keysPressed['ArrowLeft'] = false;
+	if (keyCode === RIGHT_ARROW) keysPressed['ArrowRight'] = false;
+
+	return false; // Prevent default browser behavior
+};
+
+// Handle mouse click for single mode
+window.mouseClicked = function () {
+	if (game && game.gameManager && game.gameManager.mode === 'single') {
+		// Tell player to drop fruit on click
+		game.gameManager.handleMouseClick();
+	}
+	return false;
 };

--- a/docs/app.js
+++ b/docs/app.js
@@ -14,6 +14,10 @@ const keysPressed = {
 	ArrowRight: false,
 };
 
+// Prevent immediate fruit drops triggered by clicking when mode is switched
+let modeChangeTime = 0;
+const MODE_CHANGE_DELAY = 500; // millisecond
+
 // Use window.setup because in index.html file use type module to allow import and export file.
 window.setup = function () {
 	canvas = createCanvas(1500, 1000);
@@ -102,9 +106,21 @@ window.keyReleased = function () {
 
 // Handle mouse click for single mode
 window.mouseClicked = function () {
+	if (millis() - modeChangeTime < MODE_CHANGE_DELAY) {
+		console.log('Ignore clicks after mode switching');
+		return false;
+	}
+
 	if (game && game.gameManager && game.gameManager.mode === 'single') {
 		// Tell player to drop fruit on click
 		game.gameManager.handleMouseClick();
 	}
 	return false;
+};
+
+// Callback function when game mode changes
+window.onModeChange = function () {
+	// Record when mode changes
+	modeChangeTime = millis();
+	console.log('The game mode has changed.，设置点击保护');
 };

--- a/docs/core/Game.js
+++ b/docs/core/Game.js
@@ -41,5 +41,6 @@ export class Game {
 
 	updateScale(newScale) {
 		this.scaleVal = newScale;
+		this.gameManager.updateScale(this.scaleVal);
 	}
 }

--- a/docs/core/Game.js
+++ b/docs/core/Game.js
@@ -14,6 +14,11 @@ export class Game {
 		this.currentScene = 'game';
 		this.gameManager = new GameManager(this, mode, this.scaleVal);
 		this.menuPage.hideButtons();
+
+		// Call the mode change callback to notify app.js that the game mode has changed
+		if (window.onModeChange) {
+			window.onModeChange();
+		}
 	}
 
 	setup() {

--- a/docs/core/Game.js
+++ b/docs/core/Game.js
@@ -41,6 +41,8 @@ export class Game {
 
 	updateScale(newScale) {
 		this.scaleVal = newScale;
-		this.gameManager.updateScale(this.scaleVal);
+		if (this.gameManager) {
+			this.gameManager.updateScale(this.scaleVal);
+		}
 	}
 }

--- a/docs/core/GameManager.js
+++ b/docs/core/GameManager.js
@@ -65,4 +65,33 @@ export class GameManager {
 			}
 		}
 	}
+
+	// Handle keyboard input for double mode
+	handleKeyPress(action) {
+		if (this.mode !== 'double') return;
+
+		// Determine which player's action needs to be handled
+		if (action.startsWith('player1')) {
+			const player1 = this.player[0];
+			if (player1 && player1.boards) {
+				player1.boards.handleKeyboardInput(action);
+			}
+		} else if (action.startsWith('player2')) {
+			const player2 = this.player[1];
+			if (player2 && player2.boards) {
+				player2.boards.handleKeyboardInput(action);
+			}
+		}
+	}
+
+	// Handle mouse click for single mode
+	handleMouseClick() {
+		if (this.mode !== 'single') return;
+
+		// In single mode, there's only one player
+		const player = this.player[0];
+		if (player && player.boards) {
+			player.boards.handleMouseClick();
+		}
+	}
 }

--- a/docs/core/GameManager.js
+++ b/docs/core/GameManager.js
@@ -28,7 +28,7 @@ export class GameManager {
 		if (!this.isGameOver) {
 			this.checkIsGameOver();
 		}
-
+		this.updateScale(this.scaleVal);
 		this.uiManager.ui.drawLabels();
 		this.uiManager.draw();
 

--- a/docs/models/Board.js
+++ b/docs/models/Board.js
@@ -31,6 +31,10 @@ export class Board {
 			this.mode === 'single' ? area.dashLine1 : this.id === 1 ? area.dashLine1 : area.dashLine2;
 
 		this.incidentManager = new IncidentManager(this, this.gameArea, this.endLine);
+
+		// Record game start time to prevent accidental clicks
+		this.gameStartTime = millis();
+		this.GAME_START_PROTECTION = 500;
 	}
 
 	setup() {
@@ -166,6 +170,12 @@ export class Board {
 
 	// Handle mouse click for single mode (drop fruit)
 	handleMouseClick() {
+		// Check if it is within the game protection period
+		if (millis() - this.gameStartTime < this.GAME_START_PROTECTION) {
+			console.log('Game just started, ignore click');
+			return;
+		}
+
 		if (!this.currentFruit) return;
 
 		let leftBound = this.gameArea.x + this.wallWidth;

--- a/docs/models/Board.js
+++ b/docs/models/Board.js
@@ -5,7 +5,7 @@ import { Fruit } from './index.js';
 
 const DISTFROMGAME = 40;
 const DISTFROMSHOP = 150;
-const KEYBOARD_MOVE_SPEED = 10;
+const KEYBOARD_MOVE_SPEED = 5;
 
 export class Board {
 	constructor(player, area, scaleVal) {

--- a/docs/models/Board.js
+++ b/docs/models/Board.js
@@ -5,6 +5,7 @@ import { Fruit } from './index.js';
 
 const DISTFROMGAME = 40;
 const DISTFROMSHOP = 150;
+const KEYBOARD_MOVE_SPEED = 10;
 
 export class Board {
 	constructor(player, area, scaleVal) {
@@ -80,10 +81,20 @@ export class Board {
 		});
 
 		// end here
+
+		// Debug log to verify fruit positioning
+		console.log(
+			`Player ${this.id} initial fruit position: x=${this.currentFruit.sprite.x}, y=${this.currentFruit.sprite.y}`
+		);
 	}
 
 	update() {
-		this.handleCurrentFruit();
+		if (this.isSingleMode) {
+			this.handleCurrentFruitMouse();
+		} else {
+			this.handleCurrentFruitKeyboard();
+		}
+
 		this.handleMerging();
 
 		this.fruits = this.fruits.filter(fruit => !fruit.removed);
@@ -139,60 +150,188 @@ export class Board {
 		this.currentFruit = fruit;
 	}
 
-	handleCurrentFruit() {
-		let leftBound = this.gameArea.x + this.wallWidth;
-		let rightBound = this.gameArea.x + this.gameArea.w - this.wallWidth;
-		let topBound = this.gameArea.y + this.gameArea.h;
-		let currentMouseX = mouseX / this.scaleVal;
-		let currentMouseY = mouseY / this.scaleVal;
-
+	// Handle mouse controls (for single mode) - just track position, not dropping
+	handleCurrentFruitMouse() {
 		if (this.currentFruit && this.currentFruit?.sprite) {
-			// allow current fruit move with mouse
+			let leftBound = this.gameArea.x + this.wallWidth;
+			let rightBound = this.gameArea.x + this.gameArea.w - this.wallWidth;
+
+			// Allow current fruit to move with mouse
 			this.currentFruit.moveWithMouse(leftBound, rightBound, this.gameArea.y - DISTFROMGAME);
 			this.currentFruit.letFall();
 		} else {
-			// Timer increments when there is no current fruit
-			this.timer++;
-			if (this.timer > 10) {
-				// Change the next fruit to the current fruit
-				this.currentFruit = this.nextFruit;
-				// Generate new fruit at the top of the shop area
-				let newType = int(random(5));
-
-				const nextFruitX =
-					this.isSingleMode || this.id === 2
-						? this.shopArea.x + this.shopArea.w / 2 // Default to shop for single mode & Player 2
-						: this.displayArea.x + this.displayArea.w / 2; // Player 1 places nextFruit above display
-
-				const nextFruitY =
-					this.isSingleMode || this.id === 2
-						? this.shopArea.y - DISTFROMSHOP // Default for single mode & Player 2
-						: this.displayArea.y - DISTFROMSHOP; // Player 1 places it above display
-				this.nextFruit = new Fruit(
-					newType,
-					nextFruitX,
-					nextFruitY,
-					30 + 20 * newType,
-					this.scaleVal
-				);
-				this.nextFruit.doNotFall();
-				this.timer = 0;
-			}
+			this.handleNextFruit();
 		}
-		// When the mouse is pressed, put the current fruit into the fruits array and clear currentFruit
-		if (
-			mouseIsPressed &&
-			this.currentFruit &&
-			this.currentFruit.getXPosition() < rightBound &&
-			this.currentFruit.getXPosition() > leftBound &&
-			currentMouseX < rightBound &&
-			currentMouseX > leftBound &&
-			currentMouseY < topBound
-		) {
-			this.currentFruit.sprite.vel.y = this.gravity;
-			this.currentFruit.startFalling();
-			this.fruits.push(this.currentFruit);
-			this.currentFruit = null;
+	}
+
+	// Handle mouse click for single mode (drop fruit)
+	handleMouseClick() {
+		if (!this.currentFruit) return;
+
+		let leftBound = this.gameArea.x + this.wallWidth;
+		let rightBound = this.gameArea.x + this.gameArea.w - this.wallWidth;
+		let currentMouseX = mouseX / this.scaleVal;
+
+		// Check if mouse is in valid drop area
+		if (currentMouseX >= leftBound && currentMouseX <= rightBound) {
+			this.dropCurrentFruit();
+			console.log('Fruit dropped via mouse click');
+		}
+	}
+
+	// Handle keyboard controls (for double mode)
+	handleCurrentFruitKeyboard() {
+		if (this.currentFruit && this.currentFruit?.sprite) {
+			// Keep the fruit at the correct height above the dash line
+			this.currentFruit.sprite.y = this.gameArea.y - DISTFROMGAME;
+			this.currentFruit.letFall();
+
+			// Force velocity to zero to prevent unwanted movement
+			this.currentFruit.sprite.vel.y = 0;
+		} else {
+			this.handleNextFruit();
+		}
+	}
+
+	// Handle keyboard input for the current fruit
+	handleKeyboardInput(action) {
+		if (!this.currentFruit || !this.currentFruit?.sprite) return;
+
+		let leftBound = this.gameArea.x + this.wallWidth;
+		let rightBound = this.gameArea.x + this.gameArea.w - this.wallWidth;
+
+		console.log(`Player ${this.id} received action: ${action}`);
+
+		switch (action) {
+			case 'player1-left':
+				if (this.id === 1) {
+					this.moveCurrentFruitLeft(leftBound);
+					console.log(`Player 1 fruit moved left: ${this.currentFruit.sprite.x}`);
+				}
+				break;
+			case 'player1-right':
+				if (this.id === 1) {
+					this.moveCurrentFruitRight(rightBound);
+					console.log(`Player 1 fruit moved right: ${this.currentFruit.sprite.x}`);
+				}
+				break;
+			case 'player1-drop':
+				if (this.id === 1) {
+					this.dropCurrentFruit();
+					console.log('Player 1 fruit dropped');
+				}
+				break;
+			case 'player2-left':
+				if (this.id === 2) {
+					this.moveCurrentFruitLeft(leftBound);
+					console.log(`Player 2 fruit moved left: ${this.currentFruit.sprite.x}`);
+				}
+				break;
+			case 'player2-right':
+				if (this.id === 2) {
+					this.moveCurrentFruitRight(rightBound);
+					console.log(`Player 2 fruit moved right: ${this.currentFruit.sprite.x}`);
+				}
+				break;
+			case 'player2-drop':
+				if (this.id === 2) {
+					this.dropCurrentFruit();
+					console.log('Player 2 fruit dropped');
+				}
+				break;
+		}
+	}
+
+	// Move the current fruit left
+	moveCurrentFruitLeft(leftBound) {
+		if (!this.currentFruit) return;
+
+		const newX = this.currentFruit.sprite.x - KEYBOARD_MOVE_SPEED;
+		// Make sure the fruit stays within bounds
+		this.currentFruit.sprite.x = constrain(
+			newX,
+			leftBound + this.currentFruit.sprite.d / 2,
+			this.currentFruit.sprite.x
+		);
+
+		// Reset vertical velocity to prevent gravity from affecting it until dropped
+		this.currentFruit.sprite.vel.y = 0;
+	}
+
+	// Move the current fruit right
+	moveCurrentFruitRight(rightBound) {
+		if (!this.currentFruit) return;
+
+		const newX = this.currentFruit.sprite.x + KEYBOARD_MOVE_SPEED;
+		// Make sure the fruit stays within bounds
+		this.currentFruit.sprite.x = constrain(
+			newX,
+			this.currentFruit.sprite.x,
+			rightBound - this.currentFruit.sprite.d / 2
+		);
+
+		// Reset vertical velocity to prevent gravity from affecting it until dropped
+		this.currentFruit.sprite.vel.y = 0;
+	}
+
+	// Drop the current fruit
+	dropCurrentFruit() {
+		if (!this.currentFruit) return;
+
+		this.currentFruit.sprite.vel.y = this.gravity;
+		this.currentFruit.startFalling();
+		this.fruits.push(this.currentFruit);
+		this.currentFruit = null;
+	}
+
+	// Handle switching to the next fruit
+	handleNextFruit() {
+		// Timer increments when there is no current fruit
+		this.timer++;
+		if (this.timer > 10) {
+			// Change the next fruit to the current fruit
+			this.currentFruit = this.nextFruit;
+
+			if (this.currentFruit) {
+				if (this.isSingleMode) {
+					// In single player mode, immediately place the fruit at the current mouse position
+					let leftBound = this.gameArea.x + this.wallWidth;
+					let rightBound = this.gameArea.x + this.gameArea.w - this.wallWidth;
+					let scaledMouseX = mouseX / this.scaleVal;
+
+					// Limited to within game boundaries
+					let newX = constrain(
+						scaledMouseX,
+						leftBound + this.currentFruit.sprite.d / 2,
+						rightBound - this.currentFruit.sprite.d / 2
+					);
+
+					// Set Position Match Mouse Now
+					this.currentFruit.sprite.x = newX;
+					this.currentFruit.sprite.y = this.gameArea.y - DISTFROMGAME;
+				} else {
+					// In two-player mode, place in the center of the game area
+					this.currentFruit.sprite.x = this.gameArea.x + this.gameArea.w / 2;
+					this.currentFruit.sprite.y = this.gameArea.y - DISTFROMGAME;
+				}
+			}
+
+			// Generate new fruit at the top of the shop area
+			let newType = int(random(5));
+
+			const nextFruitX =
+				this.isSingleMode || this.id === 2
+					? this.shopArea.x + this.shopArea.w / 2 // Default to shop for single mode & Player 2
+					: this.displayArea.x + this.displayArea.w / 2; // Player 1 places nextFruit above display
+
+			const nextFruitY =
+				this.isSingleMode || this.id === 2
+					? this.shopArea.y - DISTFROMSHOP // Default for single mode & Player 2
+					: this.displayArea.y - DISTFROMSHOP; // Player 1 places it above display
+
+			this.nextFruit = new Fruit(newType, nextFruitX, nextFruitY, 30 + 20 * newType, this.scaleVal);
+			this.nextFruit.doNotFall();
+			this.timer = 0;
 		}
 	}
 

--- a/docs/models/Fruit.js
+++ b/docs/models/Fruit.js
@@ -33,6 +33,10 @@ export class Fruit {
 		this.isFrozen = false;
 		this.scaleVal = scaleVal;
 
+		// Default to zero velocity - important for keyboard controls
+		this.sprite.vel.x = 0;
+		this.sprite.vel.y = 0;
+
 		this.sprite.draw = () => {
 			push();
 			switch (true) {
@@ -119,16 +123,22 @@ export class Fruit {
 		ellipse(leftEyeX, eyeY, eyeSize * 2, eyeSize * 2);
 		ellipse(rightEyeX, eyeY, eyeSize * 2, eyeSize * 2);
 
-		// Pupil Follows Mouse Movement
+		// Pupil Follows Mouse Movement in single mode or stays centered in double mode
 		function getPupilOffset(eyeX, eyeY) {
-			let scaledMouseX = mouseX / this.scaleVal;
-			let scaledMouseY = mouseY / this.scaleVal;
-			let dx = scaledMouseX - (this.sprite.x + eyeX);
-			let dy = scaledMouseY - (this.sprite.y + eyeY);
-			let angle = atan2(dy, dx);
-			let maxOffset = eyeSize * 0.4;
+			// If we're in a game context that uses mouse tracking
+			if (mouseX !== undefined && mouseY !== undefined) {
+				let scaledMouseX = mouseX / this.scaleVal;
+				let scaledMouseY = mouseY / this.scaleVal;
+				let dx = scaledMouseX - (this.sprite.x + eyeX);
+				let dy = scaledMouseY - (this.sprite.y + eyeY);
+				let angle = atan2(dy, dx);
+				let maxOffset = eyeSize * 0.4;
 
-			return createVector(cos(angle) * maxOffset, sin(angle) * maxOffset);
+				return createVector(cos(angle) * maxOffset, sin(angle) * maxOffset);
+			} else {
+				// Default eye position (looking forward)
+				return createVector(0, 0);
+			}
 		}
 
 		// Left Eye Pupil
@@ -187,6 +197,14 @@ export class Fruit {
 		this.sprite.vel.y = 0;
 	}
 
+	// Move the fruit to a specific position (for keyboard control)
+	moveTo(x, y) {
+		this.sprite.x = x;
+		this.sprite.y = y;
+		this.sprite.vel.x = 0;
+		this.sprite.vel.y = 0;
+	}
+
 	remove() {
 		this.removed = true;
 		this.sprite.remove();
@@ -212,6 +230,8 @@ export class Fruit {
 
 	doNotFall() {
 		this.sprite.collider = 'static';
+		this.sprite.vel.x = 0;
+		this.sprite.vel.y = 0;
 	}
 
 	letFall() {


### PR DESCRIPTION
The first version of add keyboard control:
- Now, the left player can use `a` and `d` (both upper and lower case) to move the fruit, use the `s` key to drop the fruit, and the right player can use `->`, `<-` and down arrow to control the fruit.
- Also modified when clicking the single mode on the menu page and turning the page to the game page, the first fruit won't drop.
- Modified the fruit won't drop continuously if the mouse isn't released.