### PR TITLE
#modify key guide

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -77,14 +77,6 @@ window.windowResized = function () {
 	canvas.elt.style.top = '0px';
 	if (game) {
 		game.updateScale(scaleVal);
-
-		// Make sure store indicator position updates after window resizing
-		if (game.gameManager && game.gameManager.uiManager && game.gameManager.uiManager.shop) {
-			// Use a short delay to ensure that all element positions are updated
-			setTimeout(() => {
-				game.gameManager.uiManager.shop.updateIndicatorPositions();
-			}, 50);
-		}
 	}
 };
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -12,13 +12,15 @@ const keysPressed = {
 	D: false,
 	ArrowLeft: false,
 	ArrowRight: false,
+	ArrowUp: false,
 };
 
 const extraKeysPressed = {
 	q: false,
-	Q: false,
+	//Q: false,
 	e: false,
-	E: false,
+	//E: false,
+	w: false,
 	'.': false,
 	'>': false,
 	'/': false,
@@ -75,6 +77,14 @@ window.windowResized = function () {
 	canvas.elt.style.top = '0px';
 	if (game) {
 		game.updateScale(scaleVal);
+
+		// Make sure store indicator position updates after window resizing
+		if (game.gameManager && game.gameManager.uiManager && game.gameManager.uiManager.shop) {
+			// Use a short delay to ensure that all element positions are updated
+			setTimeout(() => {
+				game.gameManager.uiManager.shop.updateIndicatorPositions();
+			}, 50);
+		}
 	}
 };
 
@@ -85,10 +95,12 @@ window.keyPressed = function () {
 
 	if (keyCode === LEFT_ARROW) keysPressed['ArrowLeft'] = true;
 	if (keyCode === RIGHT_ARROW) keysPressed['ArrowRight'] = true;
+	if (keyCode === UP_ARROW) keysPressed['ArrowUp'] = true; // Add up arrow key
 
 	// Track additional key states
 	if (key === 'q' || key === 'Q') extraKeysPressed['q'] = true;
 	if (key === 'e' || key === 'E') extraKeysPressed['e'] = true;
+	if (key === 'w' || key === 'W') extraKeysPressed['w'] = true; // Add w key
 	if (key === '.' || key === '>') extraKeysPressed['.'] = true;
 	if (key === '/' || key === '?') extraKeysPressed['/'] = true;
 
@@ -113,12 +125,20 @@ window.keyPressed = function () {
 					shop.player1Browse('next');
 				}
 
+				if (key === 'w' || key === 'W') {
+					shop.player1Browse('prev');
+				}
+
 				if (key === 'e' || key === 'E') {
 					shop.player1Buy();
 				}
 
 				if (key === '.' || key === '>') {
 					shop.player2Browse('next');
+				}
+
+				if (keyCode === UP_ARROW) {
+					shop.player2Browse('prev');
 				}
 
 				if (key === '/' || key === '?') {
@@ -138,8 +158,10 @@ window.keyReleased = function () {
 
 	if (keyCode === LEFT_ARROW) keysPressed['ArrowLeft'] = false;
 	if (keyCode === RIGHT_ARROW) keysPressed['ArrowRight'] = false;
+	if (keyCode === UP_ARROW) keysPressed['ArrowUp'] = false;
 
 	if (key === 'q' || key === 'Q') extraKeysPressed['q'] = false;
+	if (key === 'w' || key === 'W') extraKeysPressed['w'] = false;
 	if (key === 'e' || key === 'E') extraKeysPressed['e'] = false;
 	if (key === '.' || key === '>') extraKeysPressed['.'] = false;
 	if (key === '/' || key === '?') extraKeysPressed['/'] = false;

--- a/docs/app.js
+++ b/docs/app.js
@@ -7,9 +7,7 @@ let game,
 // Track pressed keys for continuous movement
 const keysPressed = {
 	a: false,
-	A: false,
 	d: false,
-	D: false,
 	ArrowLeft: false,
 	ArrowRight: false,
 	ArrowUp: false,
@@ -17,14 +15,10 @@ const keysPressed = {
 
 const extraKeysPressed = {
 	q: false,
-	//Q: false,
 	e: false,
-	//E: false,
 	w: false,
 	'.': false,
-	'>': false,
 	'/': false,
-	'?': false,
 };
 
 // Prevent immediate fruit drops triggered by clicking when mode is switched
@@ -93,8 +87,8 @@ window.keyPressed = function () {
 	if (key === 'q' || key === 'Q') extraKeysPressed['q'] = true;
 	if (key === 'e' || key === 'E') extraKeysPressed['e'] = true;
 	if (key === 'w' || key === 'W') extraKeysPressed['w'] = true; // Add w key
-	if (key === '.' || key === '>') extraKeysPressed['.'] = true;
-	if (key === '/' || key === '?') extraKeysPressed['/'] = true;
+	if (key === '.' || key === '。') extraKeysPressed['.'] = true;
+	if (key === '/') extraKeysPressed['/'] = true;
 
 	if (game && game.gameManager) {
 		// Handle drop keys only on initial press
@@ -125,7 +119,7 @@ window.keyPressed = function () {
 					shop.player1Buy();
 				}
 
-				if (key === '.' || key === '>') {
+				if (key === '/') {
 					shop.player2Browse('next');
 				}
 
@@ -133,7 +127,7 @@ window.keyPressed = function () {
 					shop.player2Browse('prev');
 				}
 
-				if (key === '/' || key === '?') {
+				if (key === '。' || key === '.') {
 					shop.player2Buy();
 				}
 			}
@@ -155,8 +149,8 @@ window.keyReleased = function () {
 	if (key === 'q' || key === 'Q') extraKeysPressed['q'] = false;
 	if (key === 'w' || key === 'W') extraKeysPressed['w'] = false;
 	if (key === 'e' || key === 'E') extraKeysPressed['e'] = false;
-	if (key === '.' || key === '>') extraKeysPressed['.'] = false;
-	if (key === '/' || key === '?') extraKeysPressed['/'] = false;
+	if (key === '.' || key === '。') extraKeysPressed['.'] = false;
+	if (key === '/') extraKeysPressed['/'] = false;
 
 	return false; // Prevent default browser behavior
 };

--- a/docs/core/GameManager.js
+++ b/docs/core/GameManager.js
@@ -50,7 +50,6 @@ export class GameManager {
 		if (this.uiManager && this.uiManager.shop) {
 			// Force all button positions and indicators to update once
 			this.uiManager.shop.updateAllButtonPositions(this.uiManager.AREAS.shop);
-			this.uiManager.shop.updateIndicatorPositions();
 		}
 	}
 
@@ -234,6 +233,9 @@ export class GameManager {
 		this.scaleVal = newScale;
 		for (const player of this.player) {
 			player.boards.updateScale(newScale);
+		}
+		if (this.uiManager) {
+			this.uiManager.updateScale(newScale);
 		}
 	}
 	goToMainMenu() {

--- a/docs/core/GameManager.js
+++ b/docs/core/GameManager.js
@@ -45,6 +45,13 @@ export class GameManager {
 				player.boards.incidentBegin();
 			}
 		});
+
+		// Make sure the Store indicator is displayed and updated after the tutorial ends
+		if (this.uiManager && this.uiManager.shop) {
+			// Force all button positions and indicators to update once
+			this.uiManager.shop.updateAllButtonPositions(this.uiManager.AREAS.shop);
+			this.uiManager.shop.updateIndicatorPositions();
+		}
 	}
 
 	updateTutorial() {

--- a/docs/core/GameUIManager.js
+++ b/docs/core/GameUIManager.js
@@ -30,8 +30,16 @@ export class GameUIManager {
 		this.counter.start();
 
 		if (this.isDoubleMode) {
-			this.keyGuide = new KeyGuide(this.gameManager.scaleVal * 1.5);
+			this.keyGuide = new KeyGuide();
 			this.keyGuide.setupKeyGuide(this.AREAS.display);
+		}
+	}
+
+	updateScale(newScale) {
+		this.scaleVal = newScale;
+
+		if (this.isDoubleMode && this.keyGuide) {
+			this.keyGuide.updateScale(newScale);
 		}
 	}
 

--- a/docs/core/GameUIManager.js
+++ b/docs/core/GameUIManager.js
@@ -222,6 +222,15 @@ export class GameUIManager {
 		}
 		// Draw notification message
 		this.notificationManager.update();
+
+		// Draw selector indicators last, making sure they appear at the top
+		if (this.isDoubleMode && !isTutorial && !this.gameManager.isTutorialMode && this.shop) {
+			// Use push() and pop() to save and restore drawing states
+			push();
+			// Here you can set any parameter that ensures that the indicator is clearly visible
+			this.shop.drawSelectionIndicators();
+			pop();
+		}
 	}
 
 	displayCounter() {

--- a/docs/core/TutorialManager.js
+++ b/docs/core/TutorialManager.js
@@ -270,12 +270,6 @@ export class TutorialManager {
 		if (this.gameManager && typeof this.gameManager.startActualGameAfterTutorial === 'function') {
 			this.game.currentScene = 'game';
 			this.gameManager.startActualGameAfterTutorial();
-
-			// Make sure to update the store selector display immediately after the tutorial ends
-			if (this.gameManager.uiManager && this.gameManager.uiManager.shop) {
-				// Ensure indicator position and visibility are updated immediately
-				this.gameManager.uiManager.shop.updateIndicatorPositions();
-			}
 		}
 	}
 

--- a/docs/core/TutorialManager.js
+++ b/docs/core/TutorialManager.js
@@ -270,6 +270,12 @@ export class TutorialManager {
 		if (this.gameManager && typeof this.gameManager.startActualGameAfterTutorial === 'function') {
 			this.game.currentScene = 'game';
 			this.gameManager.startActualGameAfterTutorial();
+
+			// Make sure to update the store selector display immediately after the tutorial ends
+			if (this.gameManager.uiManager && this.gameManager.uiManager.shop) {
+				// Ensure indicator position and visibility are updated immediately
+				this.gameManager.uiManager.shop.updateIndicatorPositions();
+			}
 		}
 	}
 

--- a/docs/core/TutorialManager.js
+++ b/docs/core/TutorialManager.js
@@ -102,8 +102,8 @@ export class TutorialManager {
 				},
 				{
 					title: 'Shop Controls',
-					left: ['Left Side Player 1:', '- W / Q to browse', '- E to buy'],
-					right: ['Right Side Player 2:', "- ⭡ / '.' to browse", "- '?' to buy"],
+					left: ['Left Side Player 1:', '- W and Q to browse', '- E to buy'],
+					right: ['Right Side Player 2:', "- ⭡and '/' to browse", "- '.' to buy"],
 					highlight: this.gameManager.uiManager.AREAS.shop,
 					split: true,
 					highlightKeys: ['Q', 'W', 'E', '↑', '.', '?'],

--- a/docs/models/KeyGuide.js
+++ b/docs/models/KeyGuide.js
@@ -67,7 +67,7 @@ export class KeyGuide {
 
 		let layout = [
 			[0, 0, '.'], // buy
-			[0, 1, '?'], // next
+			[0, 1, '/'], // next
 			[0, 3, '↑'], // up
 			[1, 2, '←'], // left
 			[1, 3, '↓'], // down

--- a/docs/models/KeyGuide.js
+++ b/docs/models/KeyGuide.js
@@ -2,18 +2,28 @@ export class KeyGuide {
 	constructor(scaleVal = 1) {
 		this.scaleVal = scaleVal;
 		this.highlightKeys = new Set();
+
+		this.baseKeySize = 35;
+		this.baseSpacing = 45;
+		this.baseTextSize = 24;
+	}
+
+	updateScale(newScale) {
+		this.scaleVal = newScale;
 	}
 
 	setupKeyGuide(displayArea) {
-		const baseY = displayArea.y + displayArea.h / 2 - 45 * this.scaleVal;
+		const baseY = displayArea.y + displayArea.h / 2 - this.baseSpacing;
 
 		this.leftX = displayArea.x - 150;
 		this.rightX = displayArea.x + displayArea.w + 50;
 		this.baseY = baseY;
+
+		this.displayArea = displayArea;
 	}
 
 	drawKey(x, y, label) {
-		let size = 35 * this.scaleVal;
+		let size = this.baseKeySize;
 
 		const isHighlighted = this.highlightKeys.has(label);
 
@@ -26,17 +36,17 @@ export class KeyGuide {
 			fill(255);
 			stroke(0);
 		}
-		rect(x, y, size, size, 5 * this.scaleVal);
+		rect(x, y, size, size, 5);
 		fill(0);
 		noStroke();
 		textAlign(CENTER, CENTER);
-		textSize(24 * this.scaleVal);
+		textSize(this.baseTextSize);
 		text(label, x + size / 2, y + size / 2);
 		pop();
 	}
 
 	drawLeftPlayerKeys(baseX, baseY) {
-		const spacing = 45 * this.scaleVal;
+		const spacing = this.baseSpacing;
 		let layout = [
 			[-1, 0, 'Q'],
 			[0, 0, 'W'],
@@ -53,7 +63,7 @@ export class KeyGuide {
 	}
 
 	drawRightPlayerKeys(baseX, baseY) {
-		const spacing = 45 * this.scaleVal;
+		const spacing = this.baseSpacing;
 
 		let layout = [
 			[0, 0, '.'], // buy

--- a/docs/shop/Shop.js
+++ b/docs/shop/Shop.js
@@ -12,6 +12,8 @@ export class Shop {
 		this.player1Selection = 0;
 		this.player2Selection = 0;
 
+		this.useGameIndicators = true;
+
 		// Save button color settings to toggle between checked/unchecked states
 		this.normalBgColor = '#E5C3A6';
 		this.selectedBgColor = '#D5A682'; // Darker background when selected
@@ -57,6 +59,8 @@ export class Shop {
 		const padding = 10;
 		const buttonWidth = area.w - 2 * padding;
 
+		this.shopArea = area;
+
 		this.shopItems = this.items.map((item, index) => {
 			// Create a label with a player selection indicator
 			const labelHTML = `
@@ -86,61 +90,7 @@ export class Shop {
 
 		// If it is two-person mode, initialize the selection indicator
 		if (this.isDoubleMode) {
-			this.initSelectionIndicators(area);
 			this.updateButtonStyles();
-		}
-	}
-
-	// Initialize player selection indicators
-	initSelectionIndicators(area) {
-		// Create a selection indicator for Player 1
-		this.player1Indicator = document.createElement('div');
-		this.player1Indicator.innerHTML = 'P1 ◀';
-		this.player1Indicator.style.position = 'absolute';
-		this.player1Indicator.style.color = '#FF5252';
-		this.player1Indicator.style.fontWeight = 'bold';
-		this.player1Indicator.style.fontSize = '16px';
-		this.player1Indicator.style.pointerEvents = 'none'; // Prevent interference clicks
-		document.body.appendChild(this.player1Indicator);
-
-		//
-		this.player2Indicator = document.createElement('div');
-		this.player2Indicator.innerHTML = '▶ P2';
-		this.player2Indicator.style.position = 'absolute';
-		this.player2Indicator.style.color = '#2196F3';
-		this.player2Indicator.style.fontWeight = 'bold';
-		this.player2Indicator.style.fontSize = '16px';
-		this.player2Indicator.style.pointerEvents = 'none';
-		document.body.appendChild(this.player2Indicator);
-
-		// Update indicator position
-		this.updateIndicatorPositions();
-	}
-
-	updateIndicatorPositions() {
-		if (!this.isDoubleMode || !this.player1Indicator || !this.player2Indicator) return;
-
-		const canvas = document.querySelector('canvas');
-		if (!canvas) return;
-		const canvasRect = canvas.getBoundingClientRect();
-		const scale = this.gameManager.scaleVal || 1;
-
-		// Gets the position of the currently selected button
-		const player1Button = this.shopItems[this.player1Selection];
-		const player2Button = this.shopItems[this.player2Selection];
-
-		if (player1Button && player1Button.button) {
-			const btnRect = player1Button.button.elt.getBoundingClientRect();
-			this.player1Indicator.style.left = btnRect.left - 40 + 'px';
-			this.player1Indicator.style.top = btnRect.top + btnRect.height / 2 - 8 + 'px';
-			this.player1Indicator.style.transform = `scale(${scale})`;
-		}
-
-		if (player2Button && player2Button.button) {
-			const btnRect = player2Button.button.elt.getBoundingClientRect();
-			this.player2Indicator.style.left = btnRect.right + 5 + 'px';
-			this.player2Indicator.style.top = btnRect.top + btnRect.height / 2 - 8 + 'px';
-			this.player2Indicator.style.transform = `scale(${scale})`;
 		}
 	}
 
@@ -164,25 +114,73 @@ export class Shop {
 				});
 			}
 		});
+	}
 
-		this.updateIndicatorPositions();
+	drawSelectionIndicators() {
+		if (!this.isDoubleMode || this.gameManager.isTutorialMode) return;
+
+		push();
+		textSize(15);
+		textStyle(BOLD);
+
+		// Draw Player 1 indicator (left)
+		if (this.player1Selection >= 0 && this.player1Selection < this.shopItems.length) {
+			const selectedButton = this.shopItems[this.player1Selection];
+			if (selectedButton) {
+				// Set to right alignment, ensuring that text is right aligned to the specified position
+				textAlign(LEFT, TOP);
+
+				// Place the indicator near the edge of the store area, leaving only 2 pixels apart
+				//const xPos = this.shopArea.x - 2;
+				const xPos = selectedButton.x - 2;
+
+				// Make sure the y position is aligned with the button centerline
+				//const yPos = selectedButton.y + 20;
+				const yPos = selectedButton.y - 15;
+
+				// First draw a small background shadow to enhance visibility
+				fill(0, 0, 0, 80);
+				noStroke();
+				text('P1 ▼', xPos + 1, yPos + 1);
+
+				fill('#FF5252'); // red
+				stroke('#FFFFFF'); // White stroke
+				strokeWeight(0.5); // fine stroke
+				// Draw P1 indicator
+				text('P1 ▼', xPos, yPos);
+			}
+		}
+
+		// Draw Player 2's indicator (right)
+		if (this.player2Selection >= 0 && this.player2Selection < this.shopItems.length) {
+			const selectedButton = this.shopItems[this.player2Selection];
+			if (selectedButton) {
+				textAlign(RIGHT, TOP);
+
+				// const xPos = this.shopArea.x + this.shopArea.w + 2;
+				const xPos = selectedButton.x + selectedButton.button.width + 2;
+
+				// const yPos = selectedButton.y + 20;
+				const yPos = selectedButton.y - 15;
+
+				fill(0, 0, 0, 80);
+				noStroke();
+				text('P2 ▼', xPos + 1, yPos + 1);
+
+				fill('#2196F3'); // blue
+				stroke('#FFFFFF');
+				strokeWeight(0.5);
+				text('P2 ▼', xPos, yPos);
+			}
+		}
+		pop();
 	}
 
 	resetIndicators(area) {
-		// Remove old indicators if they exist
-		if (this.player1Indicator) {
-			this.player1Indicator.remove();
-			this.player1Indicator = null;
-		}
-		if (this.player2Indicator) {
-			this.player2Indicator.remove();
-			this.player2Indicator = null;
-		}
 		this.player1Selection = 0;
 		this.player2Selection = 0;
 
-		// Reinitialize indicators
-		this.initSelectionIndicators(area);
+		// Update Button Style
 		this.updateButtonStyles();
 	}
 
@@ -206,10 +204,6 @@ export class Shop {
 	updateAllButtonPositions(shopArea) {
 		const padding = 10;
 		this.listShopItems(this.shopItems, shopArea, padding);
-
-		if (this.isDoubleMode) {
-			this.updateIndicatorPositions();
-		}
 	}
 
 	// Player 1 Browse Store Items
@@ -219,7 +213,7 @@ export class Shop {
 		// Browse items up/down
 		if (direction === 'next') {
 			this.player1Selection = (this.player1Selection + 1) % this.shopItems.length;
-		} else {
+		} else if (direction === 'prev') {
 			this.player1Selection =
 				(this.player1Selection - 1 + this.shopItems.length) % this.shopItems.length;
 		}
@@ -232,7 +226,7 @@ export class Shop {
 
 		if (direction === 'next') {
 			this.player2Selection = (this.player2Selection + 1) % this.shopItems.length;
-		} else {
+		} else if (direction === 'prev') {
 			this.player2Selection =
 				(this.player2Selection - 1 + this.shopItems.length) % this.shopItems.length;
 		}


### PR DESCRIPTION
Things changed:

1. Delete some unused code
2. Now keyguide can always show the correct size
3. Replace '?' key by '/' key, and use '/' to browse down in the shop and '.' or ‘。’ to buy tools